### PR TITLE
Updated metadata for GNOME 3.16 + 3.18

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-	"shell-version": ["3.14", "3.14.1", "3.14.2", "3.15", "3.15.1", "3.15.2", "3.16", "3.16.1"]
+	"shell-version": ["3.14", "3.14.1", "3.14.2", "3.15", "3.15.1", "3.15.2", "3.16", "3.16.1", "3.18", "3.18.1", "3.18.2"]
 	, "uuid": "grubreboot@desertconsulting.net"
 	, "name": "GRUB Reboot"
 	, "description": "This extension integrates GNOME Shell with GRUB to reboot"

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-	"shell-version": ["3.14", "3.14.1", "3.14.2", "3.15", "3.15.1", "3.15.2"]
+	"shell-version": ["3.14", "3.14.1", "3.14.2", "3.15", "3.15.1", "3.15.2", "3.16", "3.16.1"]
 	, "uuid": "grubreboot@desertconsulting.net"
 	, "name": "GRUB Reboot"
 	, "description": "This extension integrates GNOME Shell with GRUB to reboot"


### PR DESCRIPTION
Not much to say, changed 'shell-version' to allow usage on GNOME 3.16 and GNOME 3.18.