### PR TITLE
Use /boot/grub even for EFI systems when needed

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -149,7 +149,8 @@ function getFile() {
     
     if(Gio.file_new_for_path("/sys/firmware/efi").query_file_type(Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS, null) == Gio.FileType.DIRECTORY) {
         file = findFile(Gio.file_new_for_path("/boot/efi"));
-    } else {
+    }
+    if(!file) {
         file = Gio.file_new_for_path("/boot/grub/grub.cfg");
     }
     return file;


### PR DESCRIPTION
On some EFI systems (e.g. some Debian installations), grub.cfg is located in /boot/grub
instead of /boot/efi. It is better to fallback to /boot/grub/grub.cfg in case grub.cfg
isn't found in /boot/efi.