### PR TITLE
Fix wrong grub.cfg read when both Fedora and Debian are installed (EFI)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -166,7 +166,9 @@ function getFile() {
 
   let file;
 
-  if (Gio.file_new_for_path("/sys/firmware/efi").query_file_type(Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS, null) == Gio.FileType.DIRECTORY) {
+  // fedora derivatives have /etc/grub2.cfg and /etc/grub2-efi.cfg that links to the location of the BIOS and EFI installs.
+  if ((Gio.file_new_for_path("/etc/grub2-efi.cfg").query_file_type(Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS, null) == Gio.FileType.SYMBOLIC_LINK)
+      && (Gio.file_new_for_path("/sys/firmware/efi").query_file_type(Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS, null) == Gio.FileType.DIRECTORY)) {
     file = findFile(Gio.file_new_for_path("/boot/efi"));
   }
   if (!file) {


### PR DESCRIPTION
Checks the symbolic link from Fedora for efi install before taking the
first grub.cfg on the EFI partition. On debian EFI grub installs, the
proper grub.cfg is still in /boot/grub/grub.cfg.
---
Idea is on Fedora to check for the symbolic links. 
Also findFile could get away.  We could read /etc/grub2-efi.cfg symlink then /etc/grub2.cfg then if still not exists we fallback on /boot/grub/grub.cfg.
Even if Debian starts to ship grub.cfg on EFI partition, findFile randomly choose the grub.cfg friom there.
The grub menu ids would not match and grub-reboot then silently reboot on default entry.
