### PR TITLE
Fix findFile with insufficient permissions #10

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -222,7 +222,11 @@ function findFile(dir) {
 
   let rv;
   if (dir.query_file_type(Gio.FileQueryInfoFlags.NONE, null) == Gio.FileType.DIRECTORY) {
-    let fenum = dir.enumerate_children("", Gio.FileQueryInfoFlags.NONE, null);
+    try {
+      let fenum = dir.enumerate_children("", Gio.FileQueryInfoFlags.NONE, null);
+    } catch (err) {
+      return null;
+    }
     let file;
     while (!rv && (file = fenum.next_file(null))) {
       if ((file.get_file_type() == Gio.FileType.REGULAR)


### PR DESCRIPTION
Checks if enumerate_children throws an error, such as "Permission denied to access file".